### PR TITLE
Skip voices that are not installed for MaryTTS API

### DIFF
--- a/mimic3_http/app.py
+++ b/mimic3_http/app.py
@@ -317,6 +317,9 @@ def get_app(args: argparse.Namespace, request_queue: Queue, temp_dir: str):
         tech = "vits"
 
         for voice in sorted_voices:
+            if not voice.location or voice.location.startswith("https://"):
+                # Skip voices that are not yet installed
+                continue
             if voice.is_multispeaker:
                 # List each speaker separately
                 for speaker in voice.speakers:


### PR DESCRIPTION
#### Description

Programs that use the Mary-TTS compatible API will likely get confused by the large number of uninstalled voices or will throw timeout errors etc. when the data is downloading. 
With this PR I propose to change the '/voices' endpoint to only return installed voices. This is done by checking the 'voice.location' parameter for a HTTPS URL.

#### Type of PR
- [ ] Bugfix
- [x] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Use the '/voices' enpoint to get a list of installed voices.

#### Documentation
Probably needs a little note next to Mary-TTS info.
