### PR TITLE
50: Update en_US/cmu-arctic_low voice metadata

### DIFF
--- a/mimic3_tts/voices.json
+++ b/mimic3_tts/voices.json
@@ -455,8 +455,8 @@
                 "sha256_sum": "e9dd8507f4bf0c6f42458e41aea833ad0bd3f6127272335eee9bf4d58541ed67"
             },
             "config.json": {
-                "size_bytes": 3550,
-                "sha256_sum": "e98bf4210293be786fc219612f6a0ac1a67b40bb2f5fa5f7c7ddbd595638c193"
+                "size_bytes": 3583,
+                "sha256_sum": "40d55cdef742aadff581b4418763db0b559e7c49d1602c39d552cfd8ae47c249"
             },
             "generator.onnx": {
                 "size_bytes": 76359777,


### PR DESCRIPTION
### How to use this template
Under each heading below is a short outline of the information required. When submitting a PR, please delete this text and replace it with your own. 

The CLA section can be deleted entirely.

#### Description
Update `en_US/cmu-arctic_low` `config.json` voice metadata to current `size_bytes` and `sha256_sum`

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
This change can be tested with the Python API, confirming that the new voice metadata is equivalent to the actual `config.json` file metadata.
```{.py}
import os
import mimic3_tts
print("Expected", mimic3_tts._resources._VOICES["en_US/cmu-arctic_low"]["files"]["config.json"])
file_path = os.path.join(mimic3_tts.download.DEFAULT_VOICES_DOWNLOAD_DIR, "en_US/cmu-arctic_low/config.json")
print("Actual size_bytes", os.path.getsize(file_path))
with open(file_path, "rb") as f:
  print("Actual sha256_sum", mimic3_tts.utils.file_sha256_sum(f))
```

#### Documentation
Does documentation for this already exist? Are there docstrings on all the public methods you added or modified? Have these been updated?

Leaving the `en_US/cmu-arctic_low` version as is to match the version found here: https://github.com/MycroftAI/mimic3-voices/blob/master/voices/en_US/cmu-arctic_low/VERSION

#### CLA
To protect you, the project, and those who choose to use Mycroft technologies in systems they build, we ask all contributors to sign a Contributor License Agreement.

This agreement clarifies that you are granting a license to the Mycroft Project to freely use your work.  Additionally, it establishes that you retain the ownership of your contributed code and intellectual property.  As the owner, you are free to use your code in other work, obtain patents, or do anything else you choose with it.

If you haven't already signed the agreement and been added to our public [Contributors repo](https://github.com/mycroftAI/contributors) then please head to https://mycroft.ai/cla to initiate the signing process.
