### PR TITLE
Replace audioop with numpy for Python 3.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,8 +76,15 @@ pip3 install mycroft-mimic3-tts[all]
 Now you can run:
 
 ``` sh
-mimic3 'Hello world.' | aplay
+mimic3 'Hello world.'
 ```
+
+**Auto complete.**
+```sh
+source mimic3_completions.sh
+```
+
+Now you can type `mimic3 --voice [tab][tab] --speaker [tab][tab] to auto complete voices and speakers.
 
 Use `mimic3-server` and `mimic3 --remote ...` for repeated usage (much faster).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
-# ⚠️ This project is no longer actively maintained
-
-Mycroft Mimic 3 is no longer maintained and may not work on your computer anymore. [Piper TTS](https://github.com/rhasspy/piper) is the spiritual successor to Mimic 3. 
+An independent & updated Python 3.13+ fork of Mycroft's fast local neural text to speech engine.
+Not affiliated with [Piper TTS](https://github.com/rhasspy/piper), another alternative you might try.
 
 # Mimic 3
 

--- a/mimic3_completions.sh
+++ b/mimic3_completions.sh
@@ -1,0 +1,31 @@
+_mimic3_completions() {
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+    opts="-h --help --remote --stdin-format --voice -v --speaker -s --voices-dir --voices --output-dir --output-naming --id-delimiter --interactive --csv --csv-delimiter --csv-voice --mark-file --noise-scale --length-scale --noise-w --result-queue-size --process-on-blank-line --ssml --stdout --preload-voice --play-program --cuda --deterministic --seed --version --debug"
+
+    d='/home/k/.local/share/mycroft/mimic3/voices/'
+    case "$prev" in
+        --voice|-m)
+            pushd "$d" > /dev/null
+            COMPREPLY=( $(compgen -f -X '!*' -- "$cur") $(compgen -d -- "$cur") )
+            popd > /dev/null
+            return 0
+            ;;
+        --speaker)
+            pushd "$d"
+            p="${COMP_WORDS[COMP_CWORD-2]}"
+            COMPREPLY=( $(compgen -f -X '!*' -- "$cur") $(g "$cur" "${p}/speakers.txt") )
+            popd
+            return 0
+            ;;
+        *)
+            COMPREPLY=( $(compgen -W "${opts}" -- "$cur") )
+            return 0
+            ;;
+    esac
+}
+
+complete -F _mimic3_completions mimic3

--- a/mimic3_tts/tts.py
+++ b/mimic3_tts/tts.py
@@ -14,7 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 """Implementation of OpenTTS for Mimic 3"""
-import audioop
+import numpy
 import itertools
 import logging
 import re
@@ -540,7 +540,9 @@ class Mimic3TextToSpeechSystem(TextToSpeechSystem):
         audio_bytes = audio.tobytes()
 
         if settings.volume != DEFAULT_VOLUME:
-            audio_bytes = audioop.mul(audio_bytes, 2, settings.volume / 100.0)
+            audio_bytes = np.frombuffer(audio_bytes, dtype=np.int16)
+            audio_bytes = audio_bytes * (settings.volume / 100.0)
+            audio_bytes = audio_bytes.clip(-32768, 32767).astype(np.int16).tobytes()
 
         return AudioResult(
             sample_rate_hz=voice.config.audio.sample_rate,


### PR DESCRIPTION
#### Description
Please start with one or two sentence description of what this pull request does. 
Fixes #61 by replacing missing `audioop` builtin with numpy for Python 3.13

If needed follow up with as much detail as required.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
`mimic3 "Hello there. This is a test"`
