### PR TITLE
Update README.md to declare project no longer maintained

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# ⚠️ This project is no longer actively maintained
+
+Mycroft Mimic 3 is no longer maintained and may not work on your computer anymore. [Piper TTS](https://github.com/rhasspy/piper) is the spiritual successor to Mimic 3. 
+
 # Mimic 3
 
 ![mimic 3 mark 2](img/mimic3-hero.jpg)


### PR DESCRIPTION
Mimic 3 is no longer maintained. No updates will be made, and no issues will be responded to.

This updates the readme to make that very obvious. It also redirects people to Piper TTS as the alternative project.

@synesthesiam - can you confirm you're happy for the redirect to Piper?
@NeonDaniel - I just wanted to make sure there wasn't another plan for the Mimic 3 repo?

If merged, I'd suggest we also set the repo to read-only.